### PR TITLE
Linca tudor/add feature flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.2.0",
+        "flagged": "^2.0.8",
         "isotope-layout": "^3.0.6",
         "react": "^18.2.0",
         "react-countup": "^6.3.1",
@@ -8250,6 +8251,14 @@
       "integrity": "sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==",
       "dependencies": {
         "desandro-matches-selector": "^2.0.0"
+      }
+    },
+    "node_modules/flagged": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/flagged/-/flagged-2.0.8.tgz",
+      "integrity": "sha512-kB3IW4Txjj2qk60f365+Ev2DzvL79yHOcRAQYscR936tw70o/VmYCOqzZf/3Anlo3L0hTKIfCsG90viTzp533A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/flat-cache": {
@@ -23644,6 +23653,12 @@
       "requires": {
         "desandro-matches-selector": "^2.0.0"
       }
+    },
+    "flagged": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/flagged/-/flagged-2.0.8.tgz",
+      "integrity": "sha512-kB3IW4Txjj2qk60f365+Ev2DzvL79yHOcRAQYscR936tw70o/VmYCOqzZf/3Anlo3L0hTKIfCsG90viTzp533A==",
+      "requires": {}
     },
     "flat-cache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.2.0",
+    "flagged": "^2.0.8",
     "isotope-layout": "^3.0.6",
     "react": "^18.2.0",
     "react-countup": "^6.3.1",

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Disclaimer from '~/components/GDPR';
 import PreLoader from '~/components/Preloader';
 import { Tooltip } from '~/components/Tooltip';
 import Register from '~/components/Register';
+import { FlagsProvider, useFeatures } from 'flagged';
 
 function App() {
   const classicHeader = commonConfig.classicHeader;
@@ -55,8 +56,11 @@ function App() {
     window.addEventListener('scroll', checkScrollTop);
   }
 
-  return (
-    <>
+  const AppContent = () => {
+    const { darkTheme, classicHeader, testimonialsSection, registerSection } =
+      useFeatures();
+
+    return (
       <div
         style={{ position: 'relative' }}
         className={classicHeader ? '' : 'side-header'}
@@ -71,45 +75,16 @@ function App() {
           )}
 
           <div id="content" role="main">
-            <Home
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-              handleNavClick={handleNavClick}
-            ></Home>
-            <AboutUs
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></AboutUs>
-            <Services
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></Services>
-            <NecessaryDocuments
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></NecessaryDocuments>
-            <Curriculum
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></Curriculum>
-            <Testimonials
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></Testimonials>
-            <Register
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></Register>
-            <Contact
-              classicHeader={classicHeader}
-              darkTheme={darkTheme}
-            ></Contact>
+            <Home handleNavClick={handleNavClick}></Home>
+            <AboutUs />
+            <Services />
+            <NecessaryDocuments />
+            <Curriculum />
+            {testimonialsSection && <Testimonials />}
+            {registerSection && <Register />}
+            <Contact />
           </div>
-          <Footer
-            classicHeader={classicHeader}
-            darkTheme={darkTheme}
-            handleNavClick={handleNavClick}
-          ></Footer>
+          <Footer handleNavClick={handleNavClick}></Footer>
         </div>
         {/* back to top */}
         <Tooltip text="Back to Top" placement="left">
@@ -128,7 +103,20 @@ function App() {
         <TermsAndConditions darkTheme={darkTheme}></TermsAndConditions>
         <Disclaimer darkTheme={darkTheme}></Disclaimer>
       </div>
-    </>
+    );
+  };
+
+  return (
+    <FlagsProvider
+      features={{
+        classicHeader: true,
+        darkTheme: false,
+        testimonialsSection: false,
+        registerSection: false,
+      }}
+    >
+      <AppContent />
+    </FlagsProvider>
   );
 }
 

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Strings } from '~/config/Strings';
-import resumeFile from '../documents/resume.pdf';
-const AboutUs = ({ classicHeader, darkTheme }) => {
+import { useFeature } from 'flagged';
+
+const AboutUs = () => {
+  const darkTheme = useFeature('darkTheme');
+  const classicHeader = useFeature('classicHeader');
   return (
     <section id="about" className={'section ' + (darkTheme ? 'bg-dark-1' : '')}>
       <div className={'container ' + (classicHeader ? '' : 'px-lg-5')}>

--- a/src/components/ClassicHeader.jsx
+++ b/src/components/ClassicHeader.jsx
@@ -4,10 +4,13 @@ import { Tooltip } from './Tooltip';
 import { Link } from 'react-scroll';
 import { Strings } from '~/config/Strings';
 import { commonConfig } from '~/config/commonConfig';
+import { useFeatures } from 'flagged';
 
 const ClassicHeader = ({ handleNavClick }) => {
   const [stickyHeader, setStickyHeader] = useState(false);
   const [isNavModalClose, setIsNavModalClose] = useState(true);
+
+  const { testimonialsSection, registerSection } = useFeatures();
 
   const checkScrollTop = () => {
     let header = document.getElementsByClassName('primary-menu');
@@ -52,13 +55,15 @@ const ClassicHeader = ({ handleNavClick }) => {
                 setIsNavModalClose(true);
               }}
             >
-              {' '}
               <img
                 src="images/logo-light.png"
                 alt="Școala Auto CLD"
-                width={175}
-                style={{ margin: 15 }}
-              />{' '}
+                style={{
+                  margin: 15,
+                  maxWidth: 110,
+                  height: 'auto',
+                }}
+              />
             </Link>
             {/* Logo End */}
           </div>
@@ -173,40 +178,44 @@ const ClassicHeader = ({ handleNavClick }) => {
                     {Strings.header.portfolio}
                   </Link>
                 </li>
-                <li className="nav-item">
-                  <Link
-                    smooth
-                    duration={500}
-                    style={{ cursor: 'pointer' }}
-                    spy
-                    activeClass="active"
-                    className="nav-link"
-                    to="testimonial"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setIsNavModalClose(true);
-                    }}
-                  >
-                    {Strings.header.testimonials}
-                  </Link>
-                </li>
-                <li className="nav-item">
-                  <Link
-                    smooth
-                    duration={500}
-                    style={{ cursor: 'pointer' }}
-                    spy
-                    activeClass="active"
-                    className="nav-link"
-                    to="register"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setIsNavModalClose(true);
-                    }}
-                  >
-                    {Strings.header.register}
-                  </Link>
-                </li>
+                {testimonialsSection && (
+                  <li className="nav-item">
+                    <Link
+                      smooth
+                      duration={500}
+                      style={{ cursor: 'pointer' }}
+                      spy
+                      activeClass="active"
+                      className="nav-link"
+                      to="testimonial"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setIsNavModalClose(true);
+                      }}
+                    >
+                      {Strings.header.testimonials}
+                    </Link>
+                  </li>
+                )}
+                {registerSection && (
+                  <li className="nav-item">
+                    <Link
+                      smooth
+                      duration={500}
+                      style={{ cursor: 'pointer' }}
+                      spy
+                      activeClass="active"
+                      className="nav-link"
+                      to="register"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setIsNavModalClose(true);
+                      }}
+                    >
+                      {Strings.header.register}
+                    </Link>
+                  </li>
+                )}
                 <li className="nav-item">
                   <Link
                     smooth

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -2,17 +2,25 @@ import React, { useRef, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { ToastContainer, toast } from 'react-toastify';
 import { Strings } from '~/config/Strings';
+import { useFeatures } from 'flagged';
 
 import 'react-toastify/dist/ReactToastify.css';
 import { Tooltip } from './Tooltip';
 import { commonConfig } from '~/config/commonConfig';
 
-const Contact = ({ classicHeader, darkTheme }) => {
+const Contact = () => {
+  const { darkTheme, classicHeader, testimonialsSection, registerSection } =
+    useFeatures();
+
+  const backgroundColorPicker = () => {
+    if (testimonialsSection !== registerSection) {
+      return darkTheme ? 'bg-dark-2' : 'bg-light';
+    }
+    return darkTheme ? 'bg-dark-1' : '';
+  };
+
   return (
-    <section
-      id="contact"
-      className={'section ' + (darkTheme ? 'bg-dark-1' : '')}
-    >
+    <section id="contact" className={'section ' + backgroundColorPicker()}>
       <div className={'container ' + (classicHeader ? '' : 'px-lg-5')}>
         {/* Heading */}
         <div className="position-relative d-flex text-center mb-5">

--- a/src/components/Curriculum.jsx
+++ b/src/components/Curriculum.jsx
@@ -2,8 +2,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import Isotope from 'isotope-layout';
 import ProjectDetailsModal from './ProjectDetailsModal';
 import { Strings } from '~/config/Strings';
+import { useFeature } from 'flagged';
 
-const Curriculum = ({ classicHeader, darkTheme }) => {
+const Curriculum = () => {
+  const darkTheme = useFeature('darkTheme');
+  const classicHeader = useFeature('classicHeader');
+
   // init one ref to store the future isotope object
   const isotope = useRef();
   // store the filter keyword in a state

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Strings } from '~/config/Strings';
+import { useFeatures } from 'flagged';
 
-const Footer = ({ classicHeader, darkTheme, handleNavClick }) => {
+const Footer = ({ handleNavClick }) => {
+  const { darkTheme, classicHeader, testimonialsSection, registerSection } =
+    useFeatures();
+
+  const backgroundColorPicker = () => {
+    if (testimonialsSection !== registerSection) {
+      return darkTheme ? 'bg-dark-2' : 'bg-light';
+    }
+    return darkTheme ? 'bg-dark-1' : '';
+  };
+
   return (
-    <footer
-      id="footer"
-      className={'section ' + (darkTheme ? 'footer-dark bg-dark-1' : '')}
-    >
+    <footer id="footer" className={'section ' + backgroundColorPicker()}>
       <div className={'container ' + (classicHeader ? '' : 'px-lg-5')}>
         <div className="row">
           <div className="col-lg-6 text-center text-lg-start">

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,7 +3,7 @@ import Typewriter from 'typewriter-effect';
 import { Strings } from '~/config/Strings';
 import videobg from '../videos/home.mp4';
 
-const Home = ({ classicHeader, darkTheme, handleNavClick }) => {
+const Home = ({ handleNavClick }) => {
   return (
     <section id="home">
       <div className="hero-wrap">

--- a/src/components/NecessaryDocuments.jsx
+++ b/src/components/NecessaryDocuments.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Strings } from '~/config/Strings';
+import { useFeature } from 'flagged';
 
-const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
+const NecessaryDocuments = () => {
+  const darkTheme = useFeature('darkTheme');
+  const classicHeader = useFeature('classicHeader');
+
   const enrollmentDetails = [
     {
       title: 'Act de identitate sau permis de conducere',
@@ -66,24 +70,22 @@ const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
         </ul>
       );
     }
-    return <li>{element}</li>;
+    return (
+      <li className={'mb-0 ' + (darkTheme ? 'text-white' : '')}>{element}</li>
+    );
   };
 
   const renderDescription = (description) => {
     if (Array.isArray(description)) {
       return description.map((value) => {
         return (
-          <p className={'mb-0 ' + (darkTheme ? 'text-white-50' : '')}>
-            {value}
-          </p>
+          <p className={'mb-0 ' + (darkTheme ? 'text-white' : '')}>{value}</p>
         );
       });
     }
 
     return (
-      <p className={'mb-0 ' + (darkTheme ? 'text-white-50' : '')}>
-        {description}
-      </p>
+      <p className={'mb-0 ' + (darkTheme ? 'text-white' : '')}>{description}</p>
     );
   };
 
@@ -97,7 +99,7 @@ const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
         <div className="position-relative d-flex text-center mb-5">
           <h2
             className={
-              'text-24  text-uppercase fw-600 w-100 mb-0 ' +
+              'text-24 text-uppercase fw-600 w-100 mb-0 ' +
               (darkTheme ? 'text-muted opacity-1' : 'text-light opacity-4')
             }
           >
@@ -116,7 +118,9 @@ const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
         {/* Heading end*/}
         <div className="row gx-5">
           {/* Enrollment */}
-          <div className="col-md-6 pe-5">
+          <div
+            className={'col-md-6 p-4 ' + (darkTheme ? 'rounded bg-dark' : '')}
+          >
             <h2
               className={
                 'text-6 fw-600 mb-4 ' + (darkTheme ? 'text-white' : '')
@@ -148,7 +152,9 @@ const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
               ))}
           </div>
           {/* Graduation */}
-          <div className="col-md-6 ps-05">
+          <div
+            className={'col-md-6 p-4 ' + (darkTheme ? 'rounded bg-dark-2' : '')}
+          >
             <h2
               className={
                 'text-6 fw-600 mb-4 ' + (darkTheme ? 'text-white' : '')
@@ -162,7 +168,7 @@ const NecessaryDocuments = ({ classicHeader, darkTheme }) => {
                   key={index}
                   className={
                     'bg-white rounded mb-4 ' +
-                    (darkTheme ? 'bg-dark' : 'bg-white')
+                    (darkTheme ? 'bg-dark-2' : 'bg-white')
                   }
                 >
                   <h3

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -4,10 +4,23 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { Tooltip } from './Tooltip';
 import { Strings } from '~/config/Strings';
+import { useFeatures } from 'flagged';
 
-const Register = ({ classicHeader, darkTheme }) => {
+const Register = () => {
   const form = useRef();
   const [sendingMail, setSendingMail] = useState(false);
+
+  const { darkTheme, classicHeader, testimonialsSection, registerSection } =
+    useFeatures();
+
+  const backgroundColorPicker = () => {
+    if (testimonialsSection !== registerSection) {
+      if (!testimonialsSection) {
+        return darkTheme ? 'bg-dark-1' : '';
+      }
+    }
+    return darkTheme ? 'bg-dark-2' : 'bg-light';
+  };
 
   const sendEmail = (event) => {
     event.preventDefault();
@@ -81,10 +94,7 @@ const Register = ({ classicHeader, darkTheme }) => {
   };
 
   return (
-    <section
-      id="register"
-      className={'section ' + (darkTheme ? 'bg-dark-2' : 'bg-light')}
-    >
+    <section id="register" className={'section ' + backgroundColorPicker()}>
       <div className={'container ' + (classicHeader ? '' : 'px-lg-5')}>
         {/* Heading */}
         <div className="position-relative d-flex text-center mb-5">

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Strings } from '~/config/Strings';
+import { useFeature } from 'flagged';
 
-const Services = ({ classicHeader, darkTheme }) => {
+const Services = () => {
+  const darkTheme = useFeature('darkTheme');
+  const classicHeader = useFeature('classicHeader');
+
   // services details
   const services = [
     {

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -2,8 +2,12 @@ import React from 'react';
 
 import Slider from 'react-slick';
 import { Strings } from '~/config/Strings';
+import { useFeature } from 'flagged';
 
-const Testimonials = ({ classicHeader, darkTheme }) => {
+const Testimonials = () => {
+  const darkTheme = useFeature('darkTheme');
+  const classicHeader = useFeature('classicHeader');
+
   const reviews = [
     {
       name: 'Dennis Jacques',


### PR DESCRIPTION
### Feature Flags

Added feature flags to enable the temporary removal of the Register and/or Testimonials Section
The flags have been implemented using the [flagged](https://github.com/sergiodxa/flagged) library. It features internal state management and easy to use methods.

There have also been implemented methods to handle the background color changes in case of section removal for the Register, Contact and Footer Components. The result can be seen in the following images: 

<img width="336" alt="Screenshot 2023-03-08 at 15 33 54" src="https://user-images.githubusercontent.com/37547839/223733948-85ff108d-e341-4ff3-aae4-de532c5ba7df.png"> <img width="337" alt="Screenshot 2023-03-08 at 15 34 17" src="https://user-images.githubusercontent.com/37547839/223733963-c7772b45-6bba-4acc-959f-1522bd561c0d.png">
<img width="335" alt="Screenshot 2023-03-08 at 15 34 43" src="https://user-images.githubusercontent.com/37547839/223733972-0b44d45d-ef78-4f1b-91de-d372b3340403.png"> <img width="333" alt="Screenshot 2023-03-08 at 15 34 59" src="https://user-images.githubusercontent.com/37547839/223733981-88428d63-2219-4778-909f-268305e6bd12.png">

The floating menu also displays the sections accordingly:

<img width="771" alt="Screenshot 2023-03-08 at 16 02 54" src="https://user-images.githubusercontent.com/37547839/223734522-d56bcd9b-fb65-4b47-9462-67916d4e4332.png">
<img width="866" alt="Screenshot 2023-03-08 at 16 03 04" src="https://user-images.githubusercontent.com/37547839/223734532-81b2c7a7-37bc-4ac4-9435-06ec4567b334.png">
<img width="860" alt="Screenshot 2023-03-08 at 16 03 26" src="https://user-images.githubusercontent.com/37547839/223734534-abed827b-0104-468c-bdbe-ed584a68b99b.png">
<img width="1005" alt="Screenshot 2023-03-08 at 16 03 40" src="https://user-images.githubusercontent.com/37547839/223734536-8662b28a-ecad-4fca-9f1e-1b55098656c8.png">


